### PR TITLE
Skip some platform-dependent tests on CRAN

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: orderly
 Title: Lightweight Reproducible Reporting
-Version: 1.99.83
+Version: 1.99.84
 Authors@R: c(person("Rich", "FitzJohn", role = c("aut", "cre"),
                     email = "rich.fitzjohn@gmail.com"),
              person("Robert", "Ashton", role = "aut"),

--- a/tests/testthat/test-outpack-packet.R
+++ b/tests/testthat/test-outpack-packet.R
@@ -855,6 +855,7 @@ test_that("metadata files match their hash", {
 
 
 test_that("Files in the archive are read-only", {
+  skip_on_cran()
   src <- temp_file()
   fs::dir_create(src)
   writeLines(c(

--- a/tests/testthat/test-outpack-store.R
+++ b/tests/testthat/test-outpack-store.R
@@ -76,6 +76,7 @@ test_that("can create a filename within the store", {
 
 
 test_that("files is the store are read-only", {
+  skip_on_cran()
   obj <- file_store$new(withr::local_tempdir())
 
   f <- withr::local_tempfile()

--- a/tests/testthat/test-util.R
+++ b/tests/testthat/test-util.R
@@ -475,6 +475,7 @@ test_that("parse_json includes name argument in its errors", {
 
 
 describe("copy_files", {
+  skip_on_cran()
   src1 <- withr::local_tempfile()
   src2 <- withr::local_tempfile()
   writeLines("Hello", src1)


### PR DESCRIPTION
These are breaking the universe build, and would likely also be problematic on CRAN