### PR TITLE
Refactor root detection logic

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: orderly
 Title: Lightweight Reproducible Reporting
-Version: 1.99.88
+Version: 1.99.89
 Authors@R: c(person("Rich", "FitzJohn", role = c("aut", "cre"),
                     email = "rich.fitzjohn@gmail.com"),
              person("Robert", "Ashton", role = "aut"),

--- a/R/config.R
+++ b/R/config.R
@@ -1,5 +1,5 @@
-orderly_config_read <- function(path, call = NULL) {
-  filename <- file.path(path, "orderly_config.yml")
+orderly_config_read <- function(filename, call = NULL) {
+  path <- dirname(filename)
   assert_file_exists_relative(basename(filename), workdir = path,
                               name = "Orderly configuration", call = call)
   raw <- yaml_read(filename)
@@ -8,8 +8,7 @@ orderly_config_read <- function(path, call = NULL) {
     assert_named(raw, call = call)
   }
 
-  raw <- resolve_envvar(raw, orderly_envir_read(path, call),
-                        "orderly_config.yml")
+  raw <- resolve_envvar(raw, orderly_envir_read(path, call), basename(filename))
 
   check <- list(
     minimum_orderly_version = orderly_config_validate_minimum_orderly_version,

--- a/R/context.R
+++ b/R/context.R
@@ -16,8 +16,16 @@ orderly_context <- function(envir) {
   } else {
     path <- getwd()
     root_src <- detect_orderly_interactive_path(path)
-    root <- root_src # for now at least
-    config <- orderly_config_read(root)
+    root <- root_src
+
+    ## This can probably be tidied up a bit later?
+    dat <- orderly_find_root(root_src,
+                             require_orderly = TRUE,
+                             require_outpack = FALSE,
+                             call = call)
+    path_orderly_config <- dat$path_orderly
+
+    config <- orderly_config_read(path_orderly_config)
     src <- path
     parameters <- current_orderly_parameters(src, envir)
     parameters_values <- parameters$values

--- a/R/outpack_root.R
+++ b/R/outpack_root.R
@@ -8,7 +8,7 @@ outpack_root <- R6::R6Class(
     files = NULL,
     index = NULL,
 
-    initialize = function(path) {
+    initialize = function(path, path_orderly) {
       assert_file_exists(path)
       assert_file_exists(file.path(path, ".outpack"))
       path <- as.character(fs::path_real(path))
@@ -18,6 +18,9 @@ outpack_root <- R6::R6Class(
         self$files <- file_store$new(file.path(path, ".outpack", "files"))
       }
       self$index <- outpack_index$new(path)
+      if (!is.null(path_orderly)) {
+        self$config$orderly <- orderly_config_read(path_orderly, call)
+      }
       lockBinding("path", self)
       lockBinding("index", self)
     }

--- a/R/outpack_root.R
+++ b/R/outpack_root.R
@@ -19,7 +19,7 @@ outpack_root <- R6::R6Class(
       }
       self$index <- outpack_index$new(path)
       if (!is.null(path_orderly)) {
-        self$config$orderly <- orderly_config_read(path_orderly, call)
+        self$config$orderly <- orderly_config_read(path_orderly, NULL)
       }
       lockBinding("path", self)
       lockBinding("index", self)

--- a/R/plugin.R
+++ b/R/plugin.R
@@ -239,6 +239,9 @@ orderly_plugin_add_metadata <- function(name, field, data) {
 
 check_plugin_enabled <- function(name, config, call) {
   if (is.null(config$plugins[[name]])) {
+    ## TODO: pass filename through here, or change the error message
+    ## to simply say "orderly configuration" and point (in a hint) as
+    ## to how to enable it, which will eventually be programmatic.
     cli::cli_abort("Plugin '{name}' not enabled in 'orderly_config.yml'",
                    call = call)
   }

--- a/R/root.R
+++ b/R/root.R
@@ -326,18 +326,19 @@ orderly_find_root_locate <- function(path, call = NULL) {
   has_outpack <- !is.null(path_outpack)
   has_orderly <- !is.null(path_orderly)
 
-  if (has_outpack && has_orderly && path_outpack != path_orderly) {
-    if (fs::path_has_parent(path_outpack, path_orderly)) {
-      order <- c(orderly = path_orderly, outpack = path_outpack)
-    } else {
-      order <- c(outpack = path_outpack, orderly = path_orderly)
+  err_nesting <- has_outpack && has_orderly &&
+    dirname(path_outpack) != dirname(path_orderly)
+  if (err_nesting) {
+    dirs <- c(outpack = dirname(path_outpack), orderly = dirname(path_orderly))
+    if (fs::path_has_parent(dirs[[1]], dirs[[2]])) {
+      dirs <- dirs[2:1]
     }
     cli::cli_abort(c(
       "Found incorrectly nested orderly and outpack directories",
-      i = "{names(order)[[1]]} was found at '{order[[1]]}'",
-      i = "{names(order)[[2]]} was found at '{order[[2]]}'",
-      x = paste("{names(order)[[2]]} is nested within {names(order)[[1]]}",
-                "at {fs::path_rel(order[[2]], order[[1]])}"),
+      i = "{names(dirs)[[1]]} was found at '{dirs[[1]]}'",
+      i = "{names(dirs)[[2]]} was found at '{dirs[[2]]}'",
+      x = paste("{names(dirs)[[2]]} is nested within {names(dirs)[[1]]}",
+                "at {fs::path_rel(dirs[[2]], dirs[[1]])}"),
       i = "How did you even do this? Please let us know!"),
       call = call)
   }

--- a/R/util.R
+++ b/R/util.R
@@ -342,14 +342,14 @@ orderly_file <- function(path) {
 }
 
 
-## We could rewrite this non-recurively, this just comes from orderly
 find_file_descend <- function(target, start = ".", limit = "/") {
   root <- normalise_path(limit)
   start <- normalise_path(start)
 
   f <- function(path) {
-    if (file.exists(file.path(path, target))) {
-      return(path)
+    filename <- file.path(path, target)
+    if (file.exists(filename)) {
+      return(filename)
     }
     if (normalise_path(path) == root) {
       return(NULL)

--- a/tests/testthat/helper-outpack.R
+++ b/tests/testthat/helper-outpack.R
@@ -154,7 +154,7 @@ helper_add_git <- function(path) {
 outpack_init_no_orderly <- function(...) {
   path <- orderly_init_quietly(...)
   fs::file_delete(file.path(path, "orderly_config.yml"))
-  outpack_root$new(path)
+  outpack_root$new(path, NULL)
 }
 
 

--- a/tests/testthat/test-location.R
+++ b/tests/testthat/test-location.R
@@ -207,16 +207,16 @@ test_that("re-adding a location de-orphans packets", {
 
   expect_message(orderly_location_remove("b", root = root$a),
                  "Orphaning 2 packets")
-  expect_equal(nrow(root_open(root$a)$index$location(orphan)), 2)
+  expect_equal(nrow(root_open(root$a, FALSE)$index$location(orphan)), 2)
   expect_message(orderly_location_remove("c", root = root$a),
                  "Orphaning 3 packets")
-  expect_equal(nrow(root_open(root$a)$index$location(orphan)), 5)
+  expect_equal(nrow(root_open(root$a, FALSE)$index$location(orphan)), 5)
 
   orderly_location_add_path("b", path = root$b, root = root$a)
   expect_message(orderly_location_fetch_metadata(root = root$a),
                  "De-orphaning 2 packets")
 
-  expect_equal(nrow(root_open(root$a)$index$location(orphan)), 3)
+  expect_equal(nrow(root_open(root$a, FALSE)$index$location(orphan)), 3)
 })
 
 

--- a/tests/testthat/test-root.R
+++ b/tests/testthat/test-root.R
@@ -198,7 +198,7 @@ test_that("can identify a plain source root", {
 
 test_that("can identify a plain source root from a full root", {
   path <- test_prepare_orderly_example("explicit")
-  root <- root_open(path)
+  root <- root_open(path, FALSE)
   expect_equal(orderly_src_root(root$path, FALSE), root$path)
   expect_equal(orderly_src_root(root, FALSE), root$path)
 })
@@ -214,15 +214,15 @@ test_that("can use ORDERLY_ROOT to control the working directory", {
 
   withr::with_envvar(c(ORDERLY_ROOT = NA_character_), {
     withr::with_dir(path_a, {
-      expect_equal(root_open(NULL)$path, path_a)
-      expect_equal(root_open(path_b)$path, path_b)
+      expect_equal(root_open(NULL, FALSE)$path, path_a)
+      expect_equal(root_open(path_b, FALSE)$path, path_b)
     })
   })
 
   withr::with_envvar(c(ORDERLY_ROOT = path_c), {
     withr::with_dir(path_a, {
-      expect_equal(root_open(NULL)$path, path_c)
-      expect_equal(root_open(path_b)$path, path_b)
+      expect_equal(root_open(NULL, FALSE)$path, path_c)
+      expect_equal(root_open(path_b, FALSE)$path, path_b)
     })
   })
 })

--- a/tests/testthat/test-root.R
+++ b/tests/testthat/test-root.R
@@ -2,9 +2,9 @@ test_that("Configuration must be empty", {
   tmp <- tempfile()
   on.exit(fs::dir_delete(tmp))
   fs::dir_create(tmp)
-  writeLines(c(empty_config_contents(), "a: 1"),
-             file.path(tmp, "orderly_config.yml"))
-  expect_error(orderly_config_read(tmp),
+  filename <- file.path(tmp, "orderly_config.yml")
+  writeLines(c(empty_config_contents(), "a: 1"), filename)
+  expect_error(orderly_config_read(filename),
                "Unknown field in .+")
 })
 
@@ -14,7 +14,7 @@ test_that("Configuration must exist", {
   on.exit(fs::dir_delete(tmp))
   fs::dir_create(tmp)
   outpack_init_no_orderly(tmp)
-  expect_error(orderly_config_read(tmp),
+  expect_error(orderly_config_read(file.path(tmp, "orderly_config.yml")),
                "Orderly configuration does not exist: 'orderly_config.yml'")
 })
 
@@ -172,27 +172,17 @@ test_that("can identify a plain source root", {
   info <- test_prepare_orderly_example_separate("explicit")
   expect_equal(normalise_path(orderly_src_root(info$src, FALSE)),
                normalise_path(info$src))
-  expect_equal(
-    orderly_src_root(file.path(info$src, "src", "explicit"), TRUE),
-    orderly_src_root(info$src, FALSE))
   expect_error(
-    orderly_src_root(file.path(info$src, "src", "explicit"), FALSE),
-    "Did not find existing orderly source root in")
+    orderly_src_root(file.path(info$src, "src", "explicit")),
+    "Did not find existing orderly (or outpack) root in", fixed = TRUE)
 
   p <- file.path(info$outpack, "a", "b", "c")
   fs::dir_create(p)
 
   err <- expect_error(
-    orderly_src_root(info$outpack, FALSE),
-    "Did not find existing orderly source root in")
-  expect_equal(err$body, c(i = "Expected to find file 'orderly_config.yml'"))
-
-  err <- expect_error(
-    orderly_src_root(p, TRUE),
-    "Did not find existing orderly source root in")
-  expect_equal(err$body,
-               c(i = "Expected to find file 'orderly_config.yml'",
-                 i = "Looked in parents of this path without success"))
+    orderly_src_root(info$outpack),
+    "Did not find 'orderly_config.yml' in",
+    fixed = TRUE)
 })
 
 


### PR DESCRIPTION
I want to replace the yaml configuration, but I do not want to make the existing overcomplicated logic around root detection more complicated.  This PR does some preliminary refactoring, with the aim of reducing the number of references to `orderly_config.yml` that remain; the idea is that with this I can write a config reader that accepts whatever format we need to, and that I can then count either the json or yml as the root marker file.

I've preserved as much functionality as I could see we were using, though a few error messages will have changed very slightly