### PR TITLE
Move to json configuration

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: orderly
 Title: Lightweight Reproducible Reporting
-Version: 1.99.89
+Version: 1.99.90
 Authors@R: c(person("Rich", "FitzJohn", role = c("aut", "cre"),
                     email = "rich.fitzjohn@gmail.com"),
              person("Robert", "Ashton", role = "aut"),

--- a/R/config.R
+++ b/R/config.R
@@ -2,8 +2,7 @@ orderly_config_read <- function(filename, call = NULL) {
   path <- dirname(filename)
   assert_file_exists_relative(basename(filename), workdir = path,
                               name = "Orderly configuration", call = call)
-  raw <- yaml_read(filename)
-
+  raw <- read_config_data(filename)
   if (!is.null(raw)) {
     assert_named(raw, call = call)
   }
@@ -76,6 +75,7 @@ orderly_config_validate_plugins <- function(plugins, filename, call = NULL) {
 
 
 orderly_envir_read <- function(path, call = NULL) {
+  ## TODO: we might prefer json here too, fairly easily really
   filename <- file.path(path, "orderly_envir.yml")
   if (!file.exists(filename)) {
     return(NULL)

--- a/R/config.R
+++ b/R/config.R
@@ -25,6 +25,8 @@ orderly_config_read <- function(filename, call = NULL) {
     dat[[x]] <- check[[x]](raw[[x]], filename, call = call)
   }
 
+  dat$path_config <- filename
+
   dat
 }
 

--- a/R/config.R
+++ b/R/config.R
@@ -25,7 +25,7 @@ orderly_config_read <- function(filename, call = NULL) {
     dat[[x]] <- check[[x]](raw[[x]], filename, call = call)
   }
 
-  dat$path_config <- filename
+  attr(dat, "filename") <- filename
 
   dat
 }

--- a/R/interactive.R
+++ b/R/interactive.R
@@ -1,9 +1,10 @@
 is_plausible_orderly_report <- function(path) {
   path_split <- fs::path_split(path)[[1]]
+  name_config <- c("orderly_config.yml", "orderly_config.json")
 
   length(path_split) > 2 &&
     path_split[[length(path_split) - 1]] == "src" &&
-    file.exists(file.path(path, "../..", "orderly_config.yml"))
+    any(file.exists(file.path(path, "../..", name_config)))
 }
 
 rstudio_get_current_active_editor_path <- function() {

--- a/R/migration.R
+++ b/R/migration.R
@@ -258,7 +258,7 @@ migrate_1_99_90 <- function(path, dry_run) {
 
   if (!file.exists(path_config_yml)) {
     cli::cli_alert_info("No old-style yaml configuration found")
-    return(FALSE)
+    return(character())
   }
 
   dat <- yaml_load(read_lines(path_config_yml, warn = FALSE))
@@ -277,7 +277,7 @@ migrate_1_99_90 <- function(path, dry_run) {
     fs::file_delete(path_config_yml)
   }
 
-  TRUE
+  c(basename(path_config_yml), basename(path_config_json))
 }
 
 

--- a/R/migration.R
+++ b/R/migration.R
@@ -225,10 +225,16 @@ migrate_1_99_88 <- function(path, dry_run) {
     if (file.exists(path_old)) {
       path_new <- file.path(p, paste0(name, ".R"))
       if (file.exists(path_new)) {
-        cli::cli_alert_danger(
-          paste("Deleting 'src/{name}/orderly.R' as '{name}' also contains",
-                "'{name}.R' - {.strong please check carefully}"))
-        fs::file_delete(path_old)
+        if (dry_run) {
+          cli::cli_alert_danger(
+            paste("Would delete 'src/{name}/orderly.R' as '{name}' also",
+                  "contains '{name}.R'"))
+        } else {
+          cli::cli_alert_danger(
+            paste("Deleting 'src/{name}/orderly.R' as '{name}' also",
+                  "contains '{name}.R' - {.strong please check carefully}"))
+          fs::file_delete(path_old)
+        }
       } else {
         if (dry_run) {
           cli::cli_alert_info(

--- a/R/plugin.R
+++ b/R/plugin.R
@@ -1,10 +1,10 @@
 ##' Create an orderly plugin. A plugin is typically defined by a
 ##' package and is used to extend orderly by enabling new
 ##' functionality, declared in your orderly configuration
-##' (`orderly_config.json` or `orderly_config.yml`) and your orderly
-##' file (`<name>.R`), and affecting the running of reports primarily
-##' by creating new objects in the report environment.  This system is
-##' discussed in more detail in `vignette("plugins")`.
+##' (`orderly_config.json`) and your orderly file (`<name>.R`), and
+##' affecting the running of reports primarily by creating new objects
+##' in the report environment.  This system is discussed in more
+##' detail in `vignette("plugins")`.
 ##'
 ##' @title Register an orderly plugin
 ##'
@@ -13,12 +13,12 @@
 ##' @param config A function to read, check and process the
 ##'   configuration section in the orderly configuration.  This
 ##'   function will be passed the deserialised data from the plugin's
-##'   section of `orderly_config.json` (or `orderly_config.yml`), and
-##'   the full path to that file.  As the order of loading of plugins
-##'   is not defined, each plugin must standalone and should not try
-##'   and interact with other plugins at load. It should return a
-##'   processed copy of the configuration data, to be passed in as the
-##'   second argument to `read`.
+##'   section of `orderly_config.json, and the full path to that file.
+##'   As the order of loading of plugins is not defined, each plugin
+##'   must standalone and should not try and interact with other
+##'   plugins at load. It should return a processed copy of the
+##'   configuration data, to be passed in as the second argument to
+##'   `read`.
 ##'
 ##' @param serialise A function to serialise any metadata added by the
 ##'   plugin's functions to the outpack metadata. It will be passed a
@@ -190,10 +190,7 @@ orderly_plugin <- function(package, config, serialise, deserialise, cleanup,
 orderly_plugin_context <- function(name, envir) {
   assert_scalar_character(name, call = environment())
   ctx <- orderly_context(envir)
-  ## TODO: get configuration name from ctx and pass it through here to
-  ## eliminate the hardcoded filename
-  filename <- "orderly_config.yml"
-  check_plugin_enabled(name, ctx$config, filename, environment())
+  check_plugin_enabled(name, ctx$config, environment())
   ## Narrower view on configuration - can only see the config for the
   ## plugin itself:
   ctx$config <- ctx$config$plugins[[name]]$config
@@ -235,16 +232,15 @@ orderly_plugin_add_metadata <- function(name, field, data) {
   assert_scalar_character(field, call = environment())
   p <- get_active_packet()
   if (!is.null(p)) {
-    ## TODO: see above
-    filename <- "orderly_config.yml"
-    check_plugin_enabled(name, p$orderly$config, filename, call = environment())
+    check_plugin_enabled(name, p$orderly$config, call = environment())
     p$plugins[[name]][[field]] <- c(p$plugins[[name]][[field]], list(data))
   }
 }
 
 
-check_plugin_enabled <- function(name, config, filename, call) {
+check_plugin_enabled <- function(name, config, call) {
   if (is.null(config$plugins[[name]])) {
+    filename <- config$path_config
     cli::cli_abort(c("Plugin '{name}' not enabled in orderly configuration",
                      i = "Check or edit '{basename(filename)}'"),
                    call = call)

--- a/R/plugin.R
+++ b/R/plugin.R
@@ -240,7 +240,7 @@ orderly_plugin_add_metadata <- function(name, field, data) {
 
 check_plugin_enabled <- function(name, config, call) {
   if (is.null(config$plugins[[name]])) {
-    filename <- config$path_config
+    filename <- attr(config, "filename") %||% "orderly_config.json"
     cli::cli_abort(c("Plugin '{name}' not enabled in orderly configuration",
                      i = "Check or edit '{basename(filename)}'"),
                    call = call)

--- a/R/root.R
+++ b/R/root.R
@@ -73,21 +73,19 @@ orderly_init <- function(root = ".",
                          force = FALSE) {
   assert_scalar_character(root)
   path_orderly <- file.path(root, "orderly_config.json")
-  has_orderly_config <- file.exists(path_orderly)
+  has_orderly <- file.exists(path_orderly)
 
-  ## This little block will turn up again in a slightly different form
-  ## shortly, within the code that searches for
   path_orderly_old <- file.path(root, "orderly_config.yml")
-  has_orderly_config_old <- file.exists(path_orderly_old)
-  if (has_orderly_config_old) {
-    if (has_orderly_config) {
+  has_orderly_old <- file.exists(path_orderly_old)
+  if (has_orderly_old) {
+    if (has_orderly) {
       error_both_configurations(root)
     }
     path_orderly <- path_orderly_old
     has_orderly <- has_orderly_old
   }
 
-  if (!has_orderly_config && file.exists(root)) {
+  if (!has_orderly && file.exists(root)) {
     if (!is_directory(root)) {
       cli::cli_abort("'root' exists but is not a directory")
     }
@@ -128,7 +126,7 @@ orderly_init <- function(root = ".",
     cli::cli_alert_success("Created orderly root at '{root$path}'")
   }
 
-  if (!has_orderly_config) {
+  if (!has_orderly) {
     writeLines(empty_config_contents(), path_orderly)
   }
 

--- a/R/root.R
+++ b/R/root.R
@@ -81,9 +81,7 @@ orderly_init <- function(root = ".",
   has_orderly_config_old <- file.exists(path_orderly_old)
   if (has_orderly_config_old) {
     if (has_orderly_config) {
-      cli::cli_abort(
-        c("Both 'orderly_config.json' and 'orderly_config.yml' found",
-          i = "Delete 'orderly_config.yml' from {root} and try again"))
+      error_both_configurations(root)
     }
     path_orderly <- path_orderly_old
     has_orderly <- has_orderly_old
@@ -347,7 +345,12 @@ orderly_find_root_locate <- function(path, call = NULL) {
 
   if (has_orderly_old) {
     if (has_orderly) {
-      cli::cli_abort(
+      # This is slightly more involved than error_both_configurations
+      # to cope with the possibility that the the configurations are
+      # in different directories (since we search) even though this is
+      # very unlikely and probably just not going to be nicely
+      # resolvable.
+      cli::cli_abort( # - TODO: test
         c("Both 'orderly_config.json' and 'orderly_config.yml' found",
           i = "Looked within '{path}'",
           i = "Found new configuration: '{path_orderly}'",
@@ -405,13 +408,7 @@ orderly_find_root_here <- function(path, call) {
 
   if (has_orderly_old) {
     if (has_orderly) {
-      cli::cli_abort(
-        c("Both 'orderly_config.json' and 'orderly_config.yml' found",
-          i = "Looked within '{path}'",
-          i = "Found new configuration: '{path_orderly}'",
-          i = "Found old configuration: '{path_orderly_old}'",
-          i = "Delete '{path_orderly_old}' and try again"),
-        call = call)
+      error_both_configurations(path, call) # TODO: test
     }
     path_orderly <- path_orderly_old
     has_orderly <- has_orderly_old
@@ -428,4 +425,13 @@ orderly_find_root_here <- function(path, call) {
   list(path = path,
        path_outpack = if (has_outpack) path_outpack,
        path_orderly = if (has_orderly) path_orderly)
+}
+
+
+error_both_configurations <- function(path, call = parent.frame()) {
+  cli::cli_abort(
+    c("Both 'orderly_config.json' and 'orderly_config.yml' found",
+      i = "Looked within '{path}'",
+      i = "Delete 'orderly_config.yml' and try again"),
+    call = call)
 }

--- a/R/root.R
+++ b/R/root.R
@@ -348,7 +348,7 @@ orderly_find_root_locate <- function(path, call = NULL) {
   if (has_orderly_old) {
     if (has_orderly) {
       cli::cli_abort(
-        c("Both 'orderly_config.json' and 'orderly_config.yml'",
+        c("Both 'orderly_config.json' and 'orderly_config.yml' found",
           i = "Looked within '{path}'",
           i = "Found new configuration: '{path_orderly}'",
           i = "Found old configuration: '{path_orderly_old}'",
@@ -406,7 +406,7 @@ orderly_find_root_here <- function(path, call) {
   if (has_orderly_old) {
     if (has_orderly) {
       cli::cli_abort(
-        c("Both 'orderly_config.json' and 'orderly_config.yml'",
+        c("Both 'orderly_config.json' and 'orderly_config.yml' found",
           i = "Looked within '{path}'",
           i = "Found new configuration: '{path_orderly}'",
           i = "Found old configuration: '{path_orderly_old}'",

--- a/R/root.R
+++ b/R/root.R
@@ -140,7 +140,7 @@ orderly_init <- function(root = ".",
 }
 
 
-ORDERLY_MINIMUM_VERSION <- "1.99.88"  # nolint
+ORDERLY_MINIMUM_VERSION <- "1.99.90"  # nolint
 
 
 empty_config_contents <- function() {

--- a/R/run.R
+++ b/R/run.R
@@ -93,7 +93,7 @@
 ##'   shared drive.
 ##'
 ##' In the first instance, we have a source path at `<src>` which
-##'   contains the file `orderly_config.yml` and the directory `src/`
+##'   contains the file `orderly_config.json` and the directory `src/`
 ##'   with our source reports, and a separate path `<root>` which
 ##'   contains the directory `.outpack/` with all the metadata - it
 ##'   may also have an unpacked archive, and a `.git/` directory

--- a/R/util.R
+++ b/R/util.R
@@ -862,3 +862,13 @@ find_calling_env <- function(fn) {
 load_namespace <- function(name) {
   rlang::eval_bare(rlang::call2("loadNamespace", name))
 }
+
+
+read_config_data <- function(filename) {
+  ext <- fs::path_ext(filename)
+  if (ext == "yml") {
+    yaml_read(filename)
+  } else {
+    jsonlite::read_json(filename)
+  }
+}

--- a/inst/examples/demo/orderly_config.json
+++ b/inst/examples/demo/orderly_config.json
@@ -1,0 +1,1 @@
+{"minimum_orderly_version": "1.99.90"}

--- a/inst/examples/demo/orderly_config.yml
+++ b/inst/examples/demo/orderly_config.yml
@@ -1,1 +1,0 @@
-minimum_orderly_version: "1.99.82"

--- a/inst/examples/example.db/R/plugin.R
+++ b/inst/examples/example.db/R/plugin.R
@@ -1,9 +1,9 @@
 db_config <- function(data, filename) {
   if (!is.list(data) || is.null(names(data)) || length(data) == 0) {
-    stop("Expected a named list for orderly_config.yml:example.db")
+    stop("Expected a named list for orderly_config.json:example.db")
   }
   if (length(data$path) != 1 || !is.character(data$path)) {
-    stop("Expected a string for orderly_config.yml:example.db:path")
+    stop("Expected a string for orderly_config.json:example.db:path")
   }
   if (!file.exists(data$path)) {
     stop(sprintf(

--- a/inst/examples/simple/orderly_config.json
+++ b/inst/examples/simple/orderly_config.json
@@ -1,0 +1,1 @@
+{"minimum_orderly_version": "1.99.90"}

--- a/inst/examples/simple/orderly_config.yml
+++ b/inst/examples/simple/orderly_config.yml
@@ -1,1 +1,0 @@
-minimum_orderly_version: 1.99.82

--- a/man/orderly_init.Rd
+++ b/man/orderly_init.Rd
@@ -47,11 +47,12 @@ invisibly. Typically this is called only for its side effect.
 \description{
 Initialise an empty orderly repository, or initialise a source
 copy of an orderly repository (see Details). An orderly repository
-is defined by the presence of a file \code{orderly_config.yml} at its
-root, along with a directory \verb{.outpack/} at the same level.
+is defined by the presence of a file \code{orderly_config.json} (or
+\code{orderly_config.yml}) at its root, along with a directory
+\verb{.outpack/} at the same level.
 }
 \details{
-It is expected that \code{orderly_config.yml} will be saved in version
+It is expected that \code{orderly_config.json} will be saved in version
 control, but that \code{.outpack} will be excluded from version
 control; this means that for every clone of your project you will
 need to call \code{orderly::orderly_init()} to initialise the
@@ -62,14 +63,15 @@ You can safely call \code{orderly::orderly_init()} on an
 already-initialised directory, however, any arguments passed
 through must exactly match the configuration of the current root,
 otherwise an error will be thrown. Please use
-\link{orderly_config_set} to change the configuration, as
-this ensures that the change in configuration is possible. If
-configuration options are given but match those that the directory
-already uses, then nothing happens.
+\link{orderly_config_set} to change the configuration within
+\code{.outpack}, as this ensures that the change in configuration is
+possible. If configuration options are given but match those that
+the directory already uses, then nothing happens.  You can safely
+edit \code{orderly_config.json} yourself, at least for now.
 
 If the repository that you call \code{orderly::orderly_init()} on is
 already initialised with an \code{.outpack} directory but not an
-\code{orderly_config.yml} file, then we will write that file too.
+\code{orderly_config.json} file, then we will write that file too.
 }
 \examples{
 # We'll use an automatically cleaned-up directory for the root:

--- a/man/orderly_migrate_source.Rd
+++ b/man/orderly_migrate_source.Rd
@@ -15,10 +15,10 @@ If \code{TRUE}, you can run this function against a repository that
 is not under version control.}
 
 \item{from}{Optional minimum version to migrate from.  If \code{NULL},
-we migrate from the version indicated in your
-\code{orderly_config.yml} and assume that all older migrations have
-been applied.  You can specify a lower version here if you want
-to force migrations that would otherwise be skipped because they
+we migrate from the version indicated in your orderly
+configuration and assume that all older migrations have been
+applied.  You can specify a lower version here if you want to
+force migrations that would otherwise be skipped because they
 are assumed to be applied.  Pass \code{"0"} (as a string) to match
 all previous versions.}
 

--- a/man/orderly_plugin_register.Rd
+++ b/man/orderly_plugin_register.Rd
@@ -17,13 +17,9 @@ orderly_plugin_register(
 \item{name}{The name of the plugin, typically the package name}
 
 \item{config}{A function to read, check and process the
-configuration section in \code{orderly_config.yml}. This function
-will be passed the deserialised data from the plugin's section
-of \code{orderly_config.yml}, and the full path to that file.  As the
-order of loading of plugins is not defined, each plugin must
-standalone and should not try and interact with other plugins at
-load. It should return a processed copy of the configuration
-data, to be passed in as the second argument to \code{read}.}
+configuration section in the orderly configuration.  This
+function will be passed the deserialised data from the plugin's
+section of \verb{orderly_config.json, and the full path to that file. As the order of loading of plugins is not defined, each plugin must standalone and should not try and interact with other plugins at load. It should return a processed copy of the configuration data, to be passed in as the second argument to }read`.}
 
 \item{serialise}{A function to serialise any metadata added by the
 plugin's functions to the outpack metadata. It will be passed a
@@ -64,11 +60,11 @@ registering a plugin.
 \description{
 Create an orderly plugin. A plugin is typically defined by a
 package and is used to extend orderly by enabling new
-functionality, declared in \code{orderly_config.yml} and your orderly file,
-and affecting the running of reports primarily by creating new
-objects in the report environment.  This system is discussed in
-more detail in \code{vignette("plugins")}, but will be expanded (likely
-in breaking ways) soon.
+functionality, declared in your orderly configuration
+(\code{orderly_config.json}) and your orderly file (\verb{<name>.R}), and
+affecting the running of reports primarily by creating new objects
+in the report environment.  This system is discussed in more
+detail in \code{vignette("plugins")}.
 }
 \examples{
 # The example code from vignette("plugins") is available in the package

--- a/man/orderly_run.Rd
+++ b/man/orderly_run.Rd
@@ -169,7 +169,7 @@ shared drive.
 }
 
 In the first instance, we have a source path at \verb{<src>} which
-contains the file \code{orderly_config.yml} and the directory \verb{src/}
+contains the file \code{orderly_config.json} and the directory \verb{src/}
 with our source reports, and a separate path \verb{<root>} which
 contains the directory \verb{.outpack/} with all the metadata - it
 may also have an unpacked archive, and a \verb{.git/} directory

--- a/tests/testthat/helper-orderly.R
+++ b/tests/testthat/helper-orderly.R
@@ -42,14 +42,12 @@ copy_examples <- function(examples, path_src) {
   }
 
   if ("plugin" %in% examples) {
-    testthat::skip("write the plugin support")
     register_example_plugin()
-    config <- c(config,
-                "plugins:",
-                "  example.random:",
-                "    distribution:",
-                "      normal")
+    dat <- jsonlite::fromJSON(config)
+    dat$plugins <- list(example.random = list(distribution = "normal"))
+    config <- jsonlite::toJSON(dat, auto_unbox = TRUE, pretty = TRUE)
   }
+
   writeLines(config, file.path(path_src, "orderly_config.json"))
 
   fs::dir_create(file.path(path_src, "src"))

--- a/tests/testthat/helper-orderly.R
+++ b/tests/testthat/helper-orderly.R
@@ -13,7 +13,7 @@ test_prepare_orderly_example_separate <- function(examples, ...) {
 
   path_outpack <- file.path(tmp, "outpack")
   suppressMessages(orderly_init(path_outpack, ...))
-  fs::file_delete(file.path(path_outpack, "orderly_config.yml"))
+  fs::file_delete(file.path(path_outpack, "orderly_config.json"))
 
   path_src <- file.path(tmp, "src")
   copy_examples(examples, path_src)
@@ -24,7 +24,7 @@ test_prepare_orderly_example_separate <- function(examples, ...) {
 
 copy_examples <- function(examples, path_src) {
   if (file.exists(path_src)) {
-    config <- readLines(file.path(path_src, "orderly_config.yml"))
+    config <- readLines(file.path(path_src, "orderly_config.json"))
   } else {
     config <- empty_config_contents()
   }
@@ -42,6 +42,7 @@ copy_examples <- function(examples, path_src) {
   }
 
   if ("plugin" %in% examples) {
+    testthat::skip("write the plugin support")
     register_example_plugin()
     config <- c(config,
                 "plugins:",
@@ -49,7 +50,7 @@ copy_examples <- function(examples, path_src) {
                 "    distribution:",
                 "      normal")
   }
-  writeLines(config, file.path(path_src, "orderly_config.yml"))
+  writeLines(config, file.path(path_src, "orderly_config.json"))
 
   fs::dir_create(file.path(path_src, "src"))
   for (i in examples) {
@@ -134,4 +135,18 @@ skip_if_jsonlite_changes_error_messages <- function(doc, pattern) {
       testthat::skip("update tests for change in jsonlite error")
     }
   })
+}
+
+
+write_old_version_marker <- function(path, version) {
+  if (numeric_version(version) < "1.99.90") {
+    unlink(file.path(path, "orderly_config.json"))
+    writeLines(
+      sprintf('minimum_orderly_version: "%s"', version),
+      file.path(path, "orderly_config.yml"))
+  } else {
+    writeLines(
+      sprintf('{"minimum_orderly_version": "%s"}', version),
+      file.path(path, "orderly_config.json"))
+  }
 }

--- a/tests/testthat/helper-outpack.R
+++ b/tests/testthat/helper-outpack.R
@@ -153,7 +153,7 @@ helper_add_git <- function(path) {
 ## create a root that does not have the orderly bits.
 outpack_init_no_orderly <- function(...) {
   path <- orderly_init_quietly(...)
-  fs::file_delete(file.path(path, "orderly_config.yml"))
+  fs::file_delete(file.path(path, "orderly_config.json"))
   outpack_root$new(path, NULL)
 }
 

--- a/tests/testthat/test-compat.R
+++ b/tests/testthat/test-compat.R
@@ -123,6 +123,7 @@ test_that("can run old orderly sources directly", {
   unload_orderly2_support()
   withr::defer(unload_orderly2_support())
   path <- suppressMessages(orderly_example())
+  unlink(file.path(path, "orderly_config.json"))
   writeLines(
     'minimum_orderly_version: "1.99.0"',
     file.path(path, "orderly_config.yml"))

--- a/tests/testthat/test-init.R
+++ b/tests/testthat/test-init.R
@@ -220,3 +220,13 @@ test_that("force initialisation of non-empty directory", {
   expect_true(file.exists(file.path(tmp, ".outpack")))
   expect_true(file.exists(file.path(tmp, "orderly_config.json")))
 })
+
+
+test_that("can fail gracefully with both configurations present", {
+  tmp <- withr::local_tempdir()
+  res <- orderly_init_quietly(tmp)
+  file.create(file.path(tmp, "orderly_config.yml"))
+  expect_error(
+    orderly_init_quietly(tmp),
+    "Both 'orderly_config.json' and 'orderly_config.yml' found")
+})

--- a/tests/testthat/test-init.R
+++ b/tests/testthat/test-init.R
@@ -15,10 +15,13 @@ test_that("Can initialise a new orderly root", {
   expect_true(file.exists(tmp))
   expect_identical(normalise_path(res), normalise_path(tmp))
   root <- root_open(tmp, require_orderly = TRUE)
+  version <- numeric_version(ORDERLY_MINIMUM_VERSION)
+  filename <- file.path(tmp, "orderly_config.json")
   expect_s3_class(root, "outpack_root")
   expect_equal(
     root$config$orderly,
-    list(minimum_orderly_version = numeric_version(ORDERLY_MINIMUM_VERSION)))
+    structure(list(minimum_orderly_version = version),
+              filename = filename))
 })
 
 
@@ -33,12 +36,14 @@ test_that("initialisation leaves things unchanged", {
 test_that("can turn an outpack root into an orderly one", {
   tmp <- withr::local_tempdir()
   outpack_init_no_orderly(tmp)
-
   orderly_init_quietly(tmp)
   root2 <- root_open(tmp, require_orderly = FALSE)
+  version <- numeric_version(ORDERLY_MINIMUM_VERSION)
+  filename <- file.path(tmp, "orderly_config.json")
   expect_equal(
     root2$config$orderly,
-    list(minimum_orderly_version = numeric_version(ORDERLY_MINIMUM_VERSION)))
+    structure(list(minimum_orderly_version = version),
+              filename = filename))
   expect_s3_class(root2, "outpack_root")
 })
 

--- a/tests/testthat/test-init.R
+++ b/tests/testthat/test-init.R
@@ -152,7 +152,7 @@ test_that("inform about weirdly nested roots: orderly in outpack", {
   root <- outpack_init_no_orderly(tmp)
   p <- file.path(tmp, "a", "b")
   fs::dir_create(p)
-  file.create(file.path(p, "orderly_config.yml"))
+  file.create(file.path(p, "orderly_config.json"))
   err <- expect_error(
     withr::with_dir(p, root_open(NULL, require_orderly = TRUE)),
     "Found incorrectly nested orderly and outpack directories")
@@ -188,7 +188,7 @@ test_that("create root in wd by default", {
   path <- withr::local_tempdir()
   root <- withr::with_dir(path, suppressMessages(orderly_init()))
   expect_true(file.exists(file.path(path, ".outpack")))
-  expect_true(file.exists(file.path(path, "orderly_config.yml")))
+  expect_true(file.exists(file.path(path, "orderly_config.json")))
 })
 
 
@@ -202,7 +202,7 @@ test_that("allow rstudio files to exist for init", {
 
   expect_no_error(orderly_init_quietly(tmp))
   expect_true(file.exists(file.path(tmp, ".outpack")))
-  expect_true(file.exists(file.path(tmp, "orderly_config.yml")))
+  expect_true(file.exists(file.path(tmp, "orderly_config.json")))
 })
 
 
@@ -213,5 +213,5 @@ test_that("force initialisation of non-empty directory", {
   file.create(file.path(tmp, "file"))
   expect_no_error(orderly_init_quietly(tmp, force = TRUE))
   expect_true(file.exists(file.path(tmp, ".outpack")))
-  expect_true(file.exists(file.path(tmp, "orderly_config.yml")))
+  expect_true(file.exists(file.path(tmp, "orderly_config.json")))
 })

--- a/tests/testthat/test-init.R
+++ b/tests/testthat/test-init.R
@@ -230,3 +230,10 @@ test_that("can fail gracefully with both configurations present", {
     orderly_init_quietly(tmp),
     "Both 'orderly_config.json' and 'orderly_config.yml' found")
 })
+
+
+test_that("can run init on an old configuration", {
+  path <- suppressMessages(orderly_example())
+  write_old_version_marker(path, "1.99.82")
+  expect_no_error(orderly_init_quietly(path))
+})

--- a/tests/testthat/test-interactive.R
+++ b/tests/testthat/test-interactive.R
@@ -47,7 +47,7 @@ test_that("does not unnecessarily suggest changing working directory", {
   # Editor path is not an orderly report
   expect_no_warning(detect_orderly_interactive_path(
     path = file.path(root, "src", "explicit"),
-    editor_path = file.path(root, "orderly_config.yml")
+    editor_path = file.path(root, "orderly_config.json")
   ))
 
   # Editor path is an unsaved file

--- a/tests/testthat/test-migration.R
+++ b/tests/testthat/test-migration.R
@@ -59,11 +59,21 @@ test_that("allow dry run on unclean repo", {
 })
 
 
-test_that("don't change up-to yml", {
+test_that("don't change up-to json", {
   path <- withr::local_tempfile()
   writeLines(empty_config_contents(), path)
   res <- evaluate_promise(
-    update_minimum_orderly_version(path, ORDERLY_MINIMUM_VERSION, FALSE))
+    update_minimum_orderly_version_json(path, ORDERLY_MINIMUM_VERSION, FALSE))
+  expect_false(res$result)
+  expect_match(res$messages, "Minimum orderly version already at")
+})
+
+
+test_that("don't change up-to yml", {
+  path <- withr::local_tempfile()
+  writeLines("minimum_orderly_version: 1.99.88", path)
+  res <- evaluate_promise(
+    update_minimum_orderly_version_yml(path, "1.99.88", FALSE))
   expect_false(res$result)
   expect_match(res$messages, "Minimum orderly version already at")
 })
@@ -73,7 +83,20 @@ test_that("can increase version if required", {
   path <- withr::local_tempfile()
   writeLines(empty_config_contents(), path)
   res <- evaluate_promise(
-    update_minimum_orderly_version(path, "9.9.9", FALSE))
+    update_minimum_orderly_version_json(path, "9.9.9", FALSE))
+  expect_true(res$result)
+  expect_match(res$messages,
+               "Updated minimum orderly version from .+ to 9.9.9")
+  expect_equal(jsonlite::read_json(path),
+               list("minimum_orderly_version" = "9.9.9"))
+})
+
+
+test_that("can increase version if required (yaml)", {
+  path <- withr::local_tempfile()
+  writeLines("minimum_orderly_version: 1.99.0", path)
+  res <- evaluate_promise(
+    update_minimum_orderly_version_yml(path, "9.9.9", FALSE))
   expect_true(res$result)
   expect_match(res$messages,
                "Updated minimum orderly version from .+ to 9.9.9")
@@ -86,16 +109,19 @@ test_that("error if no minimum version key found", {
   path <- withr::local_tempfile()
   file.create(path)
   expect_error(
-    update_minimum_orderly_version(path, "2.0.0", FALSE),
+    update_minimum_orderly_version_json(path, "2.0.0", FALSE),
+    "Failed to find key 'minimum_orderly_version' in orderly config")
+  expect_error(
+    update_minimum_orderly_version_yml(path, "2.0.0", FALSE),
     "Failed to find key 'minimum_orderly_version' in orderly config")
 })
 
 
 test_that("cope with malformed yaml", {
   path <- withr::local_tempfile()
-  writeLines(rep(empty_config_contents(), 2), path)
+  writeLines(rep("minimum_orderly_version: 1.99.0", 2), path)
   expect_error(
-    update_minimum_orderly_version(path, ORDERLY_MINIMUM_VERSION, FALSE),
+    update_minimum_orderly_version_yml(path, ORDERLY_MINIMUM_VERSION, FALSE),
     "Found more than one key 'minimum_orderly_version' in orderly config")
 })
 
@@ -105,7 +131,7 @@ test_that("leave other yaml alone when updating", {
   txt <- '# a comment\nminimum_orderly_version: "0.0.1"'
   writeLines(txt, path)
   res <- evaluate_promise(
-    update_minimum_orderly_version(path, "9.9.9", FALSE))
+    update_minimum_orderly_version_yml(path, "9.9.9", FALSE))
   expect_equal(readLines(path),
                c("# a comment", 'minimum_orderly_version: "9.9.9"'))
 })
@@ -132,6 +158,7 @@ test_that("can migrate source file", {
 
 test_that("can migrate old sources", {
   path <- suppressMessages(orderly_example())
+  unlink(file.path(path, "orderly_config.json"))
   writeLines(
     'minimum_orderly_version: "1.99.0"',
     file.path(path, "orderly_config.yml"))
@@ -171,6 +198,7 @@ test_that("can migrate old sources", {
 })
 
 
+## TODO: this needs work too
 test_that("can read version from config", {
   path <- withr::local_tempdir()
   filename <- file.path(path, "orderly_config.yml")
@@ -187,9 +215,7 @@ test_that("can read version from config", {
 
 test_that("can migrate orderly.R files", {
   path <- suppressMessages(orderly_example())
-  writeLines(
-    'minimum_orderly_version: "1.99.82"',
-    file.path(path, "orderly_config.yml"))
+  write_old_version_marker(path, "1.99.82")
 
   nms <- orderly_list_src(path)
   fs::file_move(file.path(path, "src", nms, paste0(nms, ".R")),

--- a/tests/testthat/test-migration.R
+++ b/tests/testthat/test-migration.R
@@ -248,6 +248,27 @@ test_that("can migrate orderly.R files", {
 })
 
 
+test_that("delete old orderly.R files", {
+  path <- suppressMessages(orderly_example())
+  write_old_version_marker(path, "1.99.82")
+  file.create(file.path(path, "src", "data", "orderly.R"))
+  info <- helper_add_git(path)
+
+  res <- evaluate_promise(
+    orderly_migrate_source(path, to = "1.99.88", dry_run = TRUE))
+  expect_match(res$messages[[2]], "Would delete 'src/data/orderly.R'")
+  expect_true(res$result)
+  expect_equal(nrow(gert::git_status(repo = path)), 0)
+
+  res <- evaluate_promise(
+    orderly_migrate_source(path, to = "1.99.88"))
+  expect_match(res$messages[[2]], "Deleting 'src/data/orderly.R'")
+  expect_true(res$result)
+  expect_equal(nrow(gert::git_status(repo = path)), 2)
+  expect_false(file.exists(file.path(path, "src", "data", "orderly.R")))
+})
+
+
 test_that("can migrate old configuration", {
   path <- suppressMessages(orderly_example())
   write_old_version_marker(path, "1.99.88")

--- a/tests/testthat/test-migration.R
+++ b/tests/testthat/test-migration.R
@@ -1,13 +1,13 @@
 test_that("Do nothing while migrating up-to-date sources", {
   path <- suppressMessages(orderly_example())
   info <- helper_add_git(path)
+
   res <- evaluate_promise(
-    orderly_migrate_source(path, from = "0", to = "1.99.82"))
-  expect_length(res$messages, 4)
-  expect_match(res$messages[[1]], "Migrating from 1.99.0 to 1.99.82")
-  expect_match(res$messages[[2]], "Checking \\d+ files in")
-  expect_match(res$messages[[3]], "Minimum orderly version already at")
-  expect_match(res$messages[[4]], "Nothing to change")
+    orderly_migrate_source(path, from = "0"))
+  n <- length(res$messages)
+  expect_match(res$messages[[1]], "Migrating from 1.99.0 to")
+  expect_match(res$messages[[n - 1]], "Minimum orderly version already at")
+  expect_match(res$messages[[n]], "Nothing to change")
   expect_false(res$result)
 })
 
@@ -82,6 +82,12 @@ test_that("don't change up-to yml", {
 test_that("can increase version if required", {
   path <- withr::local_tempfile()
   writeLines(empty_config_contents(), path)
+  res <- evaluate_promise(
+    update_minimum_orderly_version_json(path, "9.9.9", TRUE))
+  expect_true(res$result)
+  expect_match(res$messages,
+               "Would update minimum orderly version from .+ to 9.9.9")
+
   res <- evaluate_promise(
     update_minimum_orderly_version_json(path, "9.9.9", FALSE))
   expect_true(res$result)

--- a/tests/testthat/test-orderly.R
+++ b/tests/testthat/test-orderly.R
@@ -25,7 +25,7 @@ test_that("no candidates returns empty character vector", {
   path <- test_prepare_orderly_example(character())
   fs::dir_delete(file.path(path, "src"))
   expect_setequal(dir(path, all.files = TRUE, no.. = TRUE),
-                  c(".outpack", "orderly_config.yml"))
+                  c(".outpack", "orderly_config.json"))
   expect_equal(withr::with_dir(path, orderly_list_src()), character())
   expect_equal(orderly_list_src(path), character())
 })

--- a/tests/testthat/test-outpack-config.R
+++ b/tests/testthat/test-outpack-config.R
@@ -11,9 +11,11 @@ test_that("Validate inputs to config set", {
 
 
 test_that("Setting no options does nothing", {
-  ## This is quite tedious on macs because of the resolution of the
-  ## temporary directory (/private/var vs /var)
+  ## This is quite tedious on windows and macs because of the
+  ## resolution of the temporary directory (slashes and short paths on
+  ## windows, /private/var vs /var on macs)
   skip_on_os("mac")
+  skip_on_os("windows")
   root <- create_temporary_root()
   config <- root$config
   orderly_config_set(root = root)

--- a/tests/testthat/test-outpack-config.R
+++ b/tests/testthat/test-outpack-config.R
@@ -11,6 +11,9 @@ test_that("Validate inputs to config set", {
 
 
 test_that("Setting no options does nothing", {
+  ## This is quite tedious on macs because of the resolution of the
+  ## temporary directory (/private/var vs /var)
+  skip_on_os("mac")
   root <- create_temporary_root()
   config <- root$config
   orderly_config_set(root = root)

--- a/tests/testthat/test-plugin.R
+++ b/tests/testthat/test-plugin.R
@@ -120,7 +120,7 @@ test_that("error if packet uses non-configured plugin", {
   envir <- new.env()
   expect_error(
     orderly_run_quietly("plugin", root = path, envir = envir),
-    "Plugin 'example.random' not enabled in 'orderly_config.json'",
+    "Plugin 'example.random' not enabled in orderly configuration",
     fixed = TRUE)
 })
 

--- a/tests/testthat/test-plugin.R
+++ b/tests/testthat/test-plugin.R
@@ -115,12 +115,12 @@ test_that("don't load package if plugin already loaded", {
 
 test_that("error if packet uses non-configured plugin", {
   path <- test_prepare_orderly_example("plugin")
-  writeLines(empty_config_contents(), file.path(path, "orderly_config.yml"))
+  writeLines(empty_config_contents(), file.path(path, "orderly_config.json"))
 
   envir <- new.env()
   expect_error(
     orderly_run_quietly("plugin", root = path, envir = envir),
-    "Plugin 'example.random' not enabled in 'orderly_config.yml'",
+    "Plugin 'example.random' not enabled in 'orderly_config.json'",
     fixed = TRUE)
 })
 

--- a/tests/testthat/test-root.R
+++ b/tests/testthat/test-root.R
@@ -2,8 +2,8 @@ test_that("Configuration must be empty", {
   tmp <- tempfile()
   on.exit(fs::dir_delete(tmp))
   fs::dir_create(tmp)
-  filename <- file.path(tmp, "orderly_config.yml")
-  writeLines(c(empty_config_contents(), "a: 1"), filename)
+  filename <- file.path(tmp, "orderly_config.json")
+  writeLines('{"minimum_orderly_version": "1.99.0", "a": 1}', filename)
   expect_error(orderly_config_read(filename),
                "Unknown field in .+")
 })
@@ -14,8 +14,8 @@ test_that("Configuration must exist", {
   on.exit(fs::dir_delete(tmp))
   fs::dir_create(tmp)
   outpack_init_no_orderly(tmp)
-  expect_error(orderly_config_read(file.path(tmp, "orderly_config.yml")),
-               "Orderly configuration does not exist: 'orderly_config.yml'")
+  expect_error(orderly_config_read(file.path(tmp, "orderly_config.json")),
+               "Orderly configuration does not exist: 'orderly_config.json'")
 })
 
 
@@ -25,12 +25,12 @@ test_that("error of opening an outpack root that is not an orderly root", {
 
   err <- expect_error(
     withr::with_dir(tmp, root_open(".", require_orderly = TRUE)),
-    "Did not find 'orderly_config.yml' in '.",
+    "Did not find 'orderly_config.json' in '.",
     fixed = TRUE)
   expect_equal(
     err$body,
     c(x = paste("Your directory has an '.outpack/' path, so is a valid",
-                "outpack root, but does not contain 'orderly_config.yml' so",
+                "outpack root, but does not contain 'orderly_config.json' so",
                 "cannot be used as an orderly root"),
       i = 'Please run orderly::orderly_init(".") to initialise',
       i = "See ?orderly_init for more arguments to this function"))
@@ -51,7 +51,7 @@ test_that("pass back a root", {
                    root_outpack)
   expect_error(
     root_open(root_outpack, require_orderly = TRUE),
-    sprintf("Did not find 'orderly_config.yml' in '%s'", root_outpack$path))
+    sprintf("Did not find 'orderly_config.json' in '%s'", root_outpack$path))
 })
 
 
@@ -181,7 +181,7 @@ test_that("can identify a plain source root", {
 
   err <- expect_error(
     orderly_src_root(info$outpack),
-    "Did not find 'orderly_config.yml' in",
+    "Did not find 'orderly_config.json' in",
     fixed = TRUE)
 })
 

--- a/tests/testthat/test-root.R
+++ b/tests/testthat/test-root.R
@@ -186,6 +186,16 @@ test_that("can identify a plain source root", {
 })
 
 
+test_that("error for plain source root with two configurations", {
+  info <- test_prepare_orderly_example_separate("explicit")
+  file.create(file.path(info$src, "orderly_config.yml"))
+  expect_error(
+    orderly_src_root(info$src),
+    "Both 'orderly_config.json' and 'orderly_config.yml' found")
+})
+
+
+
 test_that("can identify a plain source root from a full root", {
   path <- test_prepare_orderly_example("explicit")
   root <- root_open(path, FALSE)
@@ -215,4 +225,15 @@ test_that("can use ORDERLY_ROOT to control the working directory", {
       expect_equal(root_open(path_b, FALSE)$path, path_b)
     })
   })
+})
+
+
+test_that("Error if both configurations found", {
+  tmp <- withr::local_tempdir()
+  orderly_init_quietly(tmp)
+  file.create(file.path(tmp, "orderly_config.yml"))
+  err <- expect_error(
+    withr::with_dir(tmp, root_open(NULL, require_orderly = TRUE)),
+    "Both 'orderly_config.json' and 'orderly_config.yml' found",
+    fixed = TRUE)
 })

--- a/tests/testthat/test-root.R
+++ b/tests/testthat/test-root.R
@@ -237,3 +237,16 @@ test_that("Error if both configurations found", {
     "Both 'orderly_config.json' and 'orderly_config.yml' found",
     fixed = TRUE)
 })
+
+
+test_that("can find root in subdirectory with old configuration", {
+  path <- suppressMessages(orderly_example())
+  from <- file.path(path, "src")
+  res1 <- orderly_find_root_locate(from)
+
+  write_old_version_marker(path, "1.99.82")
+  res2 <- orderly_find_root_locate(from)
+  expect_equal(basename(res1$path_orderly), "orderly_config.yml")
+
+  expect_equal(res1$path, res2$path)
+})

--- a/tests/testthat/test-root.R
+++ b/tests/testthat/test-root.R
@@ -243,10 +243,11 @@ test_that("can find root in subdirectory with old configuration", {
   path <- suppressMessages(orderly_example())
   from <- file.path(path, "src")
   res1 <- orderly_find_root_locate(from)
+  expect_equal(basename(res1$path_orderly), "orderly_config.json")
 
   write_old_version_marker(path, "1.99.82")
   res2 <- orderly_find_root_locate(from)
-  expect_equal(basename(res1$path_orderly), "orderly_config.yml")
+  expect_equal(basename(res2$path_orderly), "orderly_config.yml")
 
   expect_equal(res1$path, res2$path)
 })

--- a/vignettes/introduction.Rmd
+++ b/vignettes/introduction.Rmd
@@ -25,7 +25,7 @@ install.packages(
 
 # Creating an empty orderly repository
 
-The first step is to initialise an empty `orderly` repository. An `orderly` repository is a directory with the file `orderly_config.yml` within it, and since version 2 also a directory `.outpack/`.  Files within the `.outpack/` directory should never be directly modified by users and this directory should be excluded from version control (see `orderly::orderly_gitignore_update`).
+The first step is to initialise an empty `orderly` repository. An `orderly` repository is a directory with the file `orderly_config.json` within it, and since version 2 also a directory `.outpack/`.  Files within the `.outpack/` directory should never be directly modified by users and this directory should be excluded from version control (see `orderly::orderly_gitignore_update`).
 
 Create an orderly repository by calling `orderly::orderly_init()`:
 
@@ -42,10 +42,10 @@ dir_tree(path, all = TRUE)
 
 This step should be performed on a completely empty directory, otherwise an error will be thrown.  Later, you will re-initialise an `orderly` repository when cloning to a new machine, such as when working with others; this is discussed in `vignette("collaboration")`.
 
-The `orderly_config.yml` file contains very little by default:
+The `orderly_config.json` file contains very little by default:
 
 ```{r, echo = FALSE, results = "asis"}
-yaml_output(readLines(file.path(path, "orderly_config.yml")))
+json_output(readLines(file.path(path, "orderly_config.json")))
 ```
 
 For this vignette, the created orderly root is in R's per-session temporary directory, which will be deleted once R exits.  If you want to use a directory that will persist across restarting R (which you would certainly want when using `orderly` on a real project!) you should replace this with a path within your home directory, or other location that you control.
@@ -454,8 +454,8 @@ Make sure to exclude some files from `git` by listing them in `.gitignore`:
 You absolutely should version control some files:
 
 - `src/` the main source of your analyses
-- `orderly_config.yml` - this high level configuration is suitable for sharing
-- Any shared resource directory (configured in `orderly_config.yml`) should probably be version controlled
+- `orderly_config.json` - this high level configuration is suitable for sharing
+- The shared resource directory (`shared/`) should probably be version controlled
 
 Your source repository will end up in multiple people's machines, each of which are configured differently. The configuration option set via `orderly::orderly_config_set` are designed to be (potentially) different for different users, so this configuration needs to be not version controlled. It also means that reports/packets can't directly refer to values set here.  This includes the directory used to save archive packets at (if enabled) and the names of locations (equivalent to git remotes).
 

--- a/vignettes/migrating.Rmd
+++ b/vignettes/migrating.Rmd
@@ -190,7 +190,7 @@ which will rewrite some simple references to `orderly2` for you.  In particular 
 * `orderly2::fn` with `orderly::fn`
 * `library(orderly2)` with `library(orderly)`
 
-It will also update the minimum required version in the `orderly_config.yml` to at least `r orderly:::ORDERLY_MINIMUM_VERSION`
+It will also update the minimum required version in the `orderly_config.json` to at least `r orderly:::ORDERLY_MINIMUM_VERSION`  (or migrate `orderly_config.yml` to `orderly_config.json` and update that file).
 
 Review the changes that this function has made by running `git diff`, and if happy commit them.
 

--- a/vignettes/plugins.Rmd
+++ b/vignettes/plugins.Rmd
@@ -22,7 +22,7 @@ This vignette is intended to primarily serve as a design document, and will be o
 
 A plugin is provided by a package, possibly it will be the only thing that a package provides.  The plugin name must (currently) be the same as the package name.  The only functions that the package needs to call are `orderly::orderly_plugin` and `orderly::orderly_plugin_register` which create and register the plugin, respectively.
 
-To make a plugin available for an orderly project, two new bits of configuration may be present in `orderly_config.yml` - one declares the plugin will be used, the other configures the plugin.
+To make a plugin available for an orderly project, two new bits of configuration may be present in `orderly_config.json` - one declares the plugin will be used, the other configures the plugin.
 
 To use a plugin for an individual report, functions from the plugin should be used, which configure and use the plugin.
 
@@ -34,7 +34,7 @@ With the yaml-less design of `orderly` (see `vignette("migrating")` if you are f
 
 As an example, we'll implement a stripped down version of the database plugin that inspired this work (see [`orderly.db](https://github.com/mrc-ide/orderly.db) for a fuller implementation). To make this work we need functions:
 
-* ...that process additional fields in `orderly_config.yml` that describe where to find the database
+* ...that process additional fields in `orderly_config.json` that describe where to find the database
 * ...that can be called from an orderly file that access the database
 * ...that can add metadata to the final orderly metadata about what was done
 
@@ -51,12 +51,14 @@ DBI::dbDisconnect(con)
 path_root <- tempfile()
 orderly::orderly_init(path_root)
 fs::dir_create(path_root)
-writeLines(c(
-  "minimum_orderly_version: 1.99.82",
-  "plugins:",
-  "  example.db:",
-  sprintf("    path: %s", path_db)),
-  file.path(path_root, "orderly_config.yml"))
+
+jsonlite::write_json(
+  list(minimum_orderly_version = "1.99.90",
+       plugins = list(
+         orderly.db = list(
+           path = path_db))),
+  file.path(path_root, "orderly_config.json"),
+  auto_unbox = TRUE)
 
 path_example <- file.path(path_root, "src", "example")
 fs::dir_create(path_example)
@@ -83,10 +85,10 @@ Here is the directory structure of our minimal project
 withr::with_dir(path_root, fs::dir_tree("."))
 ```
 
-The `orderly_config.yml` file contains the information shared by all possible uses of the plugin - in the case the connection information for the database:
+The `orderly_config.json` file contains the information shared by all possible uses of the plugin - in the case the connection information for the database:
 
 ```{r, echo = FALSE, results = "asis"}
-yaml_output(readLines(file.path(path_root, "orderly_config.yml")))
+json_output(readLines(file.path(path_root, "orderly_config.json")))
 ```
 
 Our plugin is called `example.db` and is listed within the `plugins` section, along with its configuration; in this case indicating the path where the SQLite file can be loaded from.
@@ -102,7 +104,7 @@ Normally, we imagine some calculation here but this is kept minimal for the purp
 To implement this we need to:
 
 1. create a package
-2. write a function to handle the configuration in `orderly_config.yml`
+2. write a function to handle the configuration in `orderly_config.json`
 3. write a function `query()` used in `example.R` to do the query itself
 
 ### Create a tiny package
@@ -146,7 +148,7 @@ and the `NAMESPACE` and `R/plugin.R` files are shown below.
 
 ### Handle the configuration
 
-The only required function that a plugin needs to provide is one to process the data from `orderly_config.yml`.  This is probably primarily concerned with validation so can be fairly simple at first, later we'll expand this to report errors nicely:
+The only required function that a plugin needs to provide is one to process the data from `orderly_config.json`.  This is probably primarily concerned with validation so can be fairly simple at first, later we'll expand this to report errors nicely:
 
 ```{r, export_to_package = "minimal"}
 db_config <- function(data, filename) {
@@ -156,8 +158,8 @@ db_config <- function(data, filename) {
 
 The arguments here are
 
-* `data`: the deserialised section of the `orderly_config.yml` specific to this plugin
-* `filename`: the full path to `orderly_config.yml`
+* `data`: the deserialised section of the `orderly_config.json` specific to this plugin
+* `filename`: the full path to `orderly_config.json`
 
 The return value here should be the `data` argument with any auxiliary data added after validation.
 
@@ -222,17 +224,17 @@ orderly::orderly_run("example", root = path_root)
 
 # Making the plugin more robust
 
-The plugin above is fairly fragile because it does not do any validation on the input data from `orderly_config.yml` or `orderly.yml`.  This is fairly annoying to do as yaml is incredibly flexible and reporting back information to the user about what might have gone wrong is hard.
+The plugin above is fairly fragile because it does not do any validation on the input data from `orderly_config.json`.  This is fairly annoying to do in practice, but a little effort will make the experience for a user better because they will be able to debug incorrect configuration more effectively.
 
-In our case, we expect a single key-value pair in `orderly_config.yml` with the key being `path` and the value being the path to a SQLite database. We can easily expand our configuration function to report better back to the user when they misconfigure the plugin:
+In our case, we expect a single key-value pair in `orderly_config.json` with the key being `path` and the value being the path to a SQLite database. We can easily expand our configuration function to report better back to the user when they misconfigure the plugin:
 
 ```{r, export_to_package = "full", eval = FALSE}
 db_config <- function(data, filename) {
   if (!is.list(data) || is.null(names(data)) || length(data) == 0) {
-    stop("Expected a named list for orderly_config.yml:example.db")
+    stop("Expected a JSON object for orderly_config.json:example.db")
   }
   if (length(data$path) != 1 || !is.character(data$path)) {
-    stop("Expected a string for orderly_config.yml:example.db:path")
+    stop("Expected a string for orderly_config.json:example.db:path")
   }
   if (!file.exists(data$path)) {
     stop(sprintf(
@@ -247,9 +249,9 @@ This should do an acceptable job of preventing poor input while suggesting to th
 
 # Saving metadata about what the plugin did
 
-Nothing about what the plugin does is saved into the report metadata unless you save it. Partly this is because the orderly.yml, which is saved into the final directory, serves as some sort of record.  However, you probably want to know something about the data that you returned here. For example we might want to save
+Nothing about what the plugin does is saved into the report metadata unless you save it. Partly this is because the orderly source file, which is saved into the final directory, serves as some sort of record.  However, you probably want to know something about the data that you returned here. For example we might want to save
 
-* the query string so that later we can query it without having to read and process the `orderly.yml` file
+* the query string so that later we can query it without having to read and process the orderly source file
 * some statistics about the size of the data (e.g., the number of rows returned, or the columns)
 * perhaps some summary of the content such as a hash so that we can see if the content has changed between different versions of a report
 
@@ -378,7 +380,7 @@ meta$custom$example.db
 Our need for this functionality are similar to this example - pulling out the database functionality from the original version of orderly into something that is more independent, as it turns out to be useful only in a fraction of orderly use-cases. We can imagine other potential uses though, such as:
 
 * Non-DBI-based database data extraction, or customised routines for pulling data from a database
-* Download files from some shared location just before use (e.g., SharePoint, OneDrive, AWS). The `orderly_config.yml` would contain account connection details and `orderly.yml` would contain mapping between the remote data/files and local files. Rather than writing to the environment as we do above, use the `path` argument to copy files into the correct place.
+* Download files from some shared location just before use (e.g., SharePoint, OneDrive, AWS). The `orderly_config.json` would contain account connection details and the orderly source file would contain mapping between the remote data/files and local files. Rather than writing to the environment as we do above, use the `path` argument to copy files into the correct place.
 * Pull data from some web API just before running
 
 These all follow the same basic pattern of requiring some configuration in order to be able to connect to the resource service, some specification of what resources are to be fetched, and some action to actually fetch the resource and put it into place.

--- a/vignettes/plugins.Rmd
+++ b/vignettes/plugins.Rmd
@@ -55,7 +55,7 @@ fs::dir_create(path_root)
 jsonlite::write_json(
   list(minimum_orderly_version = "1.99.90",
        plugins = list(
-         orderly.db = list(
+         example.db = list(
            path = path_db))),
   file.path(path_root, "orderly_config.json"),
   auto_unbox = TRUE)


### PR DESCRIPTION
It might be worth looking at the environment configuration too, but that can be done in another PR. The PR includes a migration, though it's not obviously do-able for anyone who uses plugins (that is only vimc I think, and I can sort them out).

This PR moves the `orderly_config.yml` to `orderly_config.json`; in most cases this file is trivial and contains only the minimum orderly version required to run a project.  We do use it as a root marker, and most of the mess in this PR is trying to do the right thing if either file (or both files) are present. In practice, I think this will be fairly straightforward though

