### PR TITLE
Don't try to change any file in a previously run packet

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: orderly
 Title: Lightweight Reproducible Reporting
-Version: 1.99.90
+Version: 1.99.91
 Authors@R: c(person("Rich", "FitzJohn", role = c("aut", "cre"),
                     email = "rich.fitzjohn@gmail.com"),
              person("Robert", "Ashton", role = "aut"),

--- a/R/migration.R
+++ b/R/migration.R
@@ -183,6 +183,7 @@ migrations <- function(current, from, to) {
 migrate_1_99_82 <- function(path, dry_run) {
   files <- dir(path, pattern = "\\.(R|Rmd|qmd|md)$",
                recursive = TRUE, ignore.case = TRUE)
+  files <- files[!grepl("^(archive|draft)[/\\\\]", files)]
   cli::cli_alert_info("Checking {length(files)} file{?s} in '{path}'")
   changed <- logical(length(files))
   for (i in seq_along(files)) {

--- a/R/migration.R
+++ b/R/migration.R
@@ -59,6 +59,13 @@
 ##' this function against source code that is not version controlled
 ##' with git.
 ##'
+##' We will refuse to migrate sources if we find the directories
+##' `archive/`, `draft/` or `.outpack/` to avoid any chance of
+##' modifying files in packets that have been previously run.  You
+##' should make a fresh clone, migrate that, push back up to GitHub
+##' (or whereever you store your sources) and pull back down into your
+##' working directory.
+##'
 ##' # Migration of very old sources
 ##'
 ##' If you have old yaml-based orderly sources, you should consult
@@ -112,6 +119,7 @@ orderly_migrate_source <- function(path = ".", dry_run = FALSE, from = NULL,
   to <- numeric_version(max(names(dat)))
 
   migrate_check_git_status(path, dry_run)
+  migrate_check_archive_status(path, dry_run)
 
   changed <- character()
   for (v in names(dat)) {
@@ -167,6 +175,29 @@ migrate_check_git_status <- function(path, dry_run) {
         c("Not migrating '{path}' as 'git status' is not clean",
           i = "Try running this in a fresh clone"))
     }
+  }
+}
+
+
+migrate_check_archive_status <- function(path, dry_run) {
+  check <- c(".outpack", "archive", "draft")
+  err <- check[file.exists(file.path(path, check))]
+  if (length(err) == 0) {
+    return()
+  }
+  if (dry_run) {
+      cli::cli_alert_warning(
+        paste("The path '{path}' does not appear to be a fresh clone, as.",
+              "it contains directories created by running orderly.",
+              "You will not be able to migrate your files, but we will still",
+              "show what needs changing, as you have used 'dry_run = TRUE'"),
+        wrap = TRUE)
+      cli::cli_alert_danger("Found {?directory/directories} {squote(err)}")
+  } else {
+    cli::cli_abort(
+      c("Not migrating '{path}' as it does not appear to be a fresh clone",
+        x = "Found {?directory/directories} {squote(err)}",
+        i = "Try running this in a fresh clone"))
   }
 }
 

--- a/man/orderly_migrate_source.Rd
+++ b/man/orderly_migrate_source.Rd
@@ -97,6 +97,13 @@ repository (though this is not enforced).  After running, review
 changes (if any) with \verb{git diff} and then commit.  You cannot run
 this function against source code that is not version controlled
 with git.
+
+We will refuse to migrate sources if we find the directories
+\verb{archive/}, \verb{draft/} or \verb{.outpack/} to avoid any chance of
+modifying files in packets that have been previously run.  You
+should make a fresh clone, migrate that, push back up to GitHub
+(or whereever you store your sources) and pull back down into your
+working directory.
 }
 
 \section{Migration of very old sources}{

--- a/tests/testthat/test-migration.R
+++ b/tests/testthat/test-migration.R
@@ -315,3 +315,50 @@ test_that("can't migrate complex old configuration", {
   expect_true(file.exists(file.path(path, "orderly_config.yml")))
   expect_false(file.exists(file.path(path, "orderly_config.json")))
 })
+
+
+test_that("leave archive files alone", {
+  path <- suppressMessages(orderly_example())
+  unlink(file.path(path, "orderly_config.json"))
+  writeLines(
+    'minimum_orderly_version: "1.99.0"',
+    file.path(path, "orderly_config.yml"))
+
+  filename <- file.path(path, "src", "data", "data.R")
+  txt <- readLines(filename)
+  writeLines(sub("^orderly_", "orderly2::orderly_", txt),
+             filename)
+
+  id <- withr::with_dir(path, orderly_run_quietly("data"))
+
+  info <- helper_add_git(path)
+
+  res <- evaluate_promise(
+    orderly_migrate_source(path, to = "1.99.82", dry_run = TRUE))
+  expect_length(res$messages, 5)
+  expect_match(res$messages[[1]], "Migrating from 1.99.0 to 1.99.82")
+  expect_match(res$messages[[2]], "Checking \\d+ files in")
+  expect_match(res$messages[[3]], "Would update 2 lines in src/data/data.R")
+  expect_match(res$messages[[4]], "Would update minimum orderly version")
+  expect_match(res$messages[[5]], "Would change 2 files")
+  expect_true(res$result)
+
+  expect_equal(nrow(gert::git_status(repo = path)), 0)
+
+  res <- evaluate_promise(
+    orderly_migrate_source(path, to = "1.99.82"))
+  expect_length(res$messages, 6)
+  expect_match(res$messages[[1]], "Migrating from 1.99.0 to 1.99.82")
+  expect_match(res$messages[[2]], "Checking \\d+ files in")
+  expect_match(res$messages[[3]], "Updated 2 lines in src/data/data.R")
+  expect_match(res$messages[[4]], "Updated minimum orderly version")
+  expect_match(res$messages[[5]], "Changed 2 files")
+  expect_match(res$messages[[6]],
+               "Please review, then add and commit these to git")
+  expect_true(res$result)
+
+  expect_equal(nrow(gert::git_status(repo = path)), 2)
+
+  txt <- readLines(file.path(path, "archive", "data", id, "data.R"))
+  expect_match(txt, "orderly2::orderly_", all = FALSE)
+})

--- a/vignettes/migrating.Rmd
+++ b/vignettes/migrating.Rmd
@@ -182,7 +182,7 @@ which needs updating to use `orderly`.  A few alternative solutions are availabl
 The best solution to use if you are happy modifying your source code.  We require a clean clone of your repository (`git status` should report no modified or unknown files).  You can then run:
 
 ```r
-orderly_migrate_source_from_orderly2()
+orderly_migrate_source()
 ```
 
 which will rewrite some simple references to `orderly2` for you.  In particular it will replace


### PR DESCRIPTION
First, I tried just excluding the files: that works quite well (first commit).  Then I figured that actually we should just prevent this entirely because it's not really safe.